### PR TITLE
Add info about secrets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Based on [nix.dev](https://nix.dev) tutorials, repository template to get you st
 
 1. Follow tutorial for [creating a binary cache](https://nix.dev/tutorials/continuous-integration-github-actions.html)
 2. Replace ``nix-getting-started-template`` in ``.github/workflows/test.yml`` with the name of your binary cache
+3. Add secrets in github for the `CACHIX_SIGNING_KEY` you just created.
 
 ## Using the project
 


### PR DESCRIPTION
I thought it would be worth mentioning that you need to add the `CACHIX_SIGNING_KEY` to Github secrets for the pushing to work. That confused me for a short while.