### PR TITLE
update-niv: Remove `GITHUB_TOKEN` action input

### DIFF
--- a/.github/workflows/update-niv.yml
+++ b/.github/workflows/update-niv.yml
@@ -24,7 +24,6 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         commit-message: "[automation] update niv dependencies"
         title: "[automation] update niv dependencies"
         branch: "automation/update-niv-dependencies"


### PR DESCRIPTION
This resolves the warning:
```
Unexpected input(s) 'GITHUB_TOKEN', valid inputs are ['token', 'path', 'commit-message', 'committer', 'author', 'signoff', 'branch', ...]
```

Note that the default for `token` is the Github token already, so no need to pass that in explicitly.

See https://github.com/peter-evans/create-pull-request#action-inputs