### PR TITLE
ci: use source archive rather than checkout action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v16
     - uses: cachix/cachix-action@v10
       with:
@@ -15,5 +14,5 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         # If you chose API tokens for write access OR if you have a private cache
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - run: nix-build
-    - run: nix-shell --run "echo OK"
+    - run: nix-build https://github.com/$GITHUB_REPOSITORY/archive/$GITHUB_SHA.tar.gz
+    - run: nix-shell https://github.com/$GITHUB_REPOSITORY/archive/$GITHUB_SHA.tar.gz --run "echo OK"


### PR DESCRIPTION
I think this is a sane default for the CI of nix projects hosted on github and gitlab.  A typical build doesn't need git history, just the source at a fixed ref.  And because of this, many projects with large histories may try to optimize their builds by using shallow clones one way or the other.  But for git hosts which serve source archives, nix has a built-in capability to bypass this problem.  And it gives you a single line you can use to reproduce the build locally, or from anywhere else, even in extremely minimal environments: not even git is required. e: Oh, and also, I don't know how often dependabot prompts you to update the version of the checkout action, but, this would get rid of that.

But this is all just my opinion, and I'm interested in yours. :)

One thing that I often forget and that might be worth underlining: on `pull_request` events, `$GITHUB_REF` is the last merge commit on the branch `refs/pull/:prNumber/merge`.  So the build would not be run on the PR's comparison branch, but on the merge of it with the PR's base branch.  e: You can see this in the current check result: the ref being downloaded is different from the one on my branch.