### PR TITLE
update-niv: Explicitly fetch niv and pre-commit packages

### DIFF
--- a/.github/workflows/update-niv.yml
+++ b/.github/workflows/update-niv.yml
@@ -11,8 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
     - uses: cachix/install-nix-action@v13
+      with:
+         nix_path: nixpkgs=./nix/nixpkgs.nix
     # https://github.com/nmattia/niv/issues/280
-    - run: GITHUB_PATH= nix-shell --run "niv update"
+    - run: GITHUB_PATH= nix-shell -p niv --run "niv update"
     - uses: cachix/cachix-action@v10
       with:
         name: nix-getting-started-template
@@ -20,7 +22,7 @@ jobs:
         # Only needed for private caches
         #authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix-build
-    - run: nix-shell --run "pre-commit run -a"
+    - run: nix-shell -p pre-commit --run "pre-commit run -a"
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,1 @@
+import (import ./sources.nix).nixpkgs


### PR DESCRIPTION
This avoids fetching all dev dependencies running the "Update niv" workflow,
which is a bit wasteful and time consuming.

The time needed for the workflow went down from ~3 min to ~1 min for my project: https://github.com/avdv/replay/actions/workflows/update-niv.yml

Also, should we also use `nix_path: nixpkgs=./nix/nixpkgs.nix` action argument for the Test workflow, too?

And, I've found it useful to trigger the update-niv action manually sometimes (I am only running the job weekly). What do you think about that?